### PR TITLE
Add simple calculator utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# https-github.com-akm100932
+# Sample Python Calculator
+
+This repository contains a simple command-line calculator implemented in Python.
+
+## Requirements
+
+Python 3.x is required.
+
+## Usage
+
+Run the script with one of the supported commands:
+
+```bash
+python calculator.py add 1 2        # Outputs 3
+python calculator.py subtract 5 3   # Outputs 2
+python calculator.py multiply 2 4   # Outputs 8
+python calculator.py divide 10 2    # Outputs 5
+```
+
+The calculator supports four basic operations: addition, subtraction, multiplication, and division. Division by zero results in an error.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ python calculator.py add 1 2        # Outputs 3
 python calculator.py subtract 5 3   # Outputs 2
 python calculator.py multiply 2 4   # Outputs 8
 python calculator.py divide 10 2    # Outputs 5
+python calculator.py power 2 3      # Outputs 8
 ```
 
-The calculator supports four basic operations: addition, subtraction, multiplication, and division. Division by zero results in an error.
+The calculator supports five basic operations: addition, subtraction, multiplication, division, and exponentiation. Division by zero results in an error.

--- a/calculator.py
+++ b/calculator.py
@@ -1,0 +1,59 @@
+import argparse
+
+
+def add(a, b):
+    return a + b
+
+
+def subtract(a, b):
+    return a - b
+
+
+def multiply(a, b):
+    return a * b
+
+
+def divide(a, b):
+    if b == 0:
+        raise ValueError("Cannot divide by zero")
+    return a / b
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple command-line calculator")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Add two numbers")
+    add_parser.add_argument("a", type=float, help="First operand")
+    add_parser.add_argument("b", type=float, help="Second operand")
+
+    sub_parser = subparsers.add_parser("subtract", help="Subtract two numbers")
+    sub_parser.add_argument("a", type=float, help="First operand")
+    sub_parser.add_argument("b", type=float, help="Second operand")
+
+    mul_parser = subparsers.add_parser("multiply", help="Multiply two numbers")
+    mul_parser.add_argument("a", type=float, help="First operand")
+    mul_parser.add_argument("b", type=float, help="Second operand")
+
+    div_parser = subparsers.add_parser("divide", help="Divide two numbers")
+    div_parser.add_argument("a", type=float, help="First operand")
+    div_parser.add_argument("b", type=float, help="Second operand")
+
+    args = parser.parse_args()
+
+    if args.command == "add":
+        result = add(args.a, args.b)
+    elif args.command == "subtract":
+        result = subtract(args.a, args.b)
+    elif args.command == "multiply":
+        result = multiply(args.a, args.b)
+    elif args.command == "divide":
+        result = divide(args.a, args.b)
+    else:
+        parser.error("Unknown command")
+
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/calculator.py
+++ b/calculator.py
@@ -19,6 +19,10 @@ def divide(a, b):
     return a / b
 
 
+def power(a, b):
+    return a ** b
+
+
 def main():
     parser = argparse.ArgumentParser(description="Simple command-line calculator")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -39,6 +43,10 @@ def main():
     div_parser.add_argument("a", type=float, help="First operand")
     div_parser.add_argument("b", type=float, help="Second operand")
 
+    pow_parser = subparsers.add_parser("power", help="Raise a to the power of b")
+    pow_parser.add_argument("a", type=float, help="Base value")
+    pow_parser.add_argument("b", type=float, help="Exponent value")
+
     args = parser.parse_args()
 
     if args.command == "add":
@@ -49,6 +57,8 @@ def main():
         result = multiply(args.a, args.b)
     elif args.command == "divide":
         result = divide(args.a, args.b)
+    elif args.command == "power":
+        result = power(args.a, args.b)
     else:
         parser.error("Unknown command")
 


### PR DESCRIPTION
## Summary
- add a command-line calculator in `calculator.py`
- update README with usage instructions

## Testing
- `python calculator.py add 1 2`
- `python calculator.py subtract 5 3`
- `python calculator.py multiply 2 4`
- `python calculator.py divide 10 2`


------
https://chatgpt.com/codex/tasks/task_e_683e63b09668832f8bc34d39c684a652